### PR TITLE
Corrected JsonSerializable implementation in JankProfiler

### DIFF
--- a/src/JankProfiler.php
+++ b/src/JankProfiler.php
@@ -58,10 +58,10 @@ class JankProfiler implements JsonSerializable
                 return $this->calls;
                 break;
             case 'json':
-                return $this->jsonSerialize(JSON_PRETTY_PRINT);
+                return json_encode($this, JSON_PRETTY_PRINT);
                 break;
             default:
-                return $this->jsonSerialize();
+                return json_encode($this);
         }
     }
 
@@ -74,11 +74,6 @@ class JankProfiler implements JsonSerializable
     public function jsonSerialize()
     {
         return $this->calls;
-    }
-
-    public function toJson($options = 0)
-    {
-        return json_encode($this->jsonSerialize(), $options);
     }
 
     public function __call($method, $args)

--- a/src/JankProfiler.php
+++ b/src/JankProfiler.php
@@ -71,9 +71,14 @@ class JankProfiler implements JsonSerializable
         $this->wrapped = null;
     }
 
-    public function jsonSerialize($options = 0)
+    public function jsonSerialize()
     {
-        return json_encode($this->calls, $options);
+        return $this->calls;
+    }
+
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
     }
 
     public function __call($method, $args)


### PR DESCRIPTION
When implementing JsonSerializable, the jsonSerialize method "Serializes the object to a value that can be serialized natively by json_encode()." This method should not return JSON itself, but rather a value that can be encoded using json_encode().

http://php.net/manual/en/jsonserializable.jsonserialize.php
